### PR TITLE
feature: create a handler to favicon path

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func parseTemplate() *template.Template {
 
 func main() {
 	tmpl := parseTemplate()
+	http.HandleFunc("/favicon.ico", http.NotFound)
 	http.HandleFunc("/", handler(tmpl))
 	http.ListenAndServe(":8080", nil)
 }


### PR DESCRIPTION
The default path "/" is called twice for each request if a path for favicon doesn't exists. With this change /favicon.ico returns 404.